### PR TITLE
Add exception handling for invalid JWT tokens

### DIFF
--- a/src/Jwt/FirebaseParser.php
+++ b/src/Jwt/FirebaseParser.php
@@ -6,6 +6,7 @@ use Firebase\JWT\ExpiredException;
 use Equip\Auth\Jwt\Configuration;
 use Equip\Auth\Exception\InvalidException;
 use Equip\Auth\Token;
+use UnexpectedValueException;
 
 /**
  * Parser for JWT authentication token strings that uses the firebase/php-jwt
@@ -41,6 +42,11 @@ class FirebaseParser implements ParserInterface
             throw new InvalidException(
                 'Token has expired: ' . $token,
                 InvalidException::CODE_TOKEN_EXPIRED
+            );
+        } catch (UnexpectedValueException $e) {
+            throw new InvalidException(
+                'Token is invalid: ' . $token,
+                InvalidException::CODE_TOKEN_INVALID
             );
         }
         return new Token($token, $metadata);

--- a/tests/Jwt/FirebaseParserTest.php
+++ b/tests/Jwt/FirebaseParserTest.php
@@ -65,6 +65,20 @@ class FirebaseParserTest extends TestCase
         }
     }
 
+    public function testParseTokenWithInvalidToken()
+    {
+        $parser = new FirebaseParser($this->config);
+
+        try {
+            $parser->parseToken(
+                'undefined'
+            );
+            $this->fail('Expected exception was not thrown');
+        } catch (InvalidException $e) {
+            $this->assertSame(InvalidException::CODE_TOKEN_INVALID, $e->getCode());
+        }
+    }
+
     public function testParseTokenWithDefaultAlgorithm()
     {
         $this->parseToken(


### PR DESCRIPTION
When passing a non-JWT string it causes an unhandled exception.

cr @shadowhand @elazar 