### PR TITLE
Add methods to InvalidException

### DIFF
--- a/src/Exception/InvalidException.php
+++ b/src/Exception/InvalidException.php
@@ -5,7 +5,8 @@ use Exception;
 
 /**
  * Exception that occurs when a user specifies an authentication token that is
- * invalid.
+ * invalid or credentials that are not recognized to obtain an authentication
+ * token.
  */
 class InvalidException extends AuthException
 {
@@ -58,6 +59,32 @@ class InvalidException extends AuthException
     {
         return new static(
             sprintf('Provided auth token `%s` is expired or otherwise invalid', $token),
+            static::CODE,
+            $previous
+        );
+    }
+
+    /**
+     * @param string $identifier
+     * @param Exception $previous
+     */
+    public static function unknownIdentifier($identifier, Exception $previous = null)
+    {
+        return new static(
+            sprintf('Specified identifier `%s` is not recognized', $identifier),
+            static::CODE,
+            $previous
+        );
+    }
+
+    /**
+     * @param string $identifier
+     * @param Exception $previous
+     */
+    public static function incorrectPassword($identifier, Exception $previous = null)
+    {
+        return new static(
+            sprintf('Incorrect password specified for identifier `%s`', $identifier),
             static::CODE,
             $previous
         );

--- a/tests/Exception/InvalidExceptionTest.php
+++ b/tests/Exception/InvalidExceptionTest.php
@@ -9,9 +9,9 @@ class InvalidExceptionTest extends \PHPUnit_Framework_TestCase
     /**
      * @param string $method
      * @param string $message
-     * @dataProvider dataProviderMethods
+     * @dataProvider dataProviderTokenMethods
      */
-    public function testMethods($method, $message)
+    public function testTokenMethods($method, $message)
     {
         $previous = new Exception('test');
         $exception = InvalidException::$method('token', $previous);
@@ -23,7 +23,7 @@ class InvalidExceptionTest extends \PHPUnit_Framework_TestCase
     /**
      * @inheritDoc
      */
-    public function dataProviderMethods()
+    public function dataProviderTokenMethods()
     {
         return [
             [
@@ -41,6 +41,37 @@ class InvalidExceptionTest extends \PHPUnit_Framework_TestCase
             [
                 'invalidToken',
                 'Provided auth token `token` is expired or otherwise invalid',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $method
+     * @param string $message
+     * @dataProvider dataProviderIdentifierMethods
+     */
+    public function testIdentifierMethods($method, $message)
+    {
+        $previous = new Exception('test');
+        $exception = InvalidException::$method('username', $previous);
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(InvalidException::CODE, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function dataProviderIdentifierMethods()
+    {
+        return [
+            [
+                'unknownIdentifier',
+                'Specified identifier `username` is not recognized',
+            ],
+            [
+                'incorrectPassword',
+                'Incorrect password specified for identifier `username`',
             ],
         ];
     }


### PR DESCRIPTION
`unknownIdentifier()` and `incorrectPassword()` should have been included in [1.1.0](https://github.com/equip/auth/commit/cee66ea759f775170f534f1fe3fe91beda4a5e6a) for [use cases](https://github.com/wheniwork/api-auth-jwt/blob/a28a8983aefd465daf38755ea8f26bbff685a906/src/AuthAdapter.php#L85-L100) that previously used the [`CODE_CREDENTIALS_INVALID` constant](https://github.com/equip/auth/commit/cee66ea759f775170f534f1fe3fe91beda4a5e6a#diff-51ec3bc57d2fb141e12c514627dd187bL12).
